### PR TITLE
DCS: Add more control of SPI transfers

### DIFF
--- a/src/DuetControlServer/DuetControlServer.xml
+++ b/src/DuetControlServer/DuetControlServer.xml
@@ -561,6 +561,11 @@
             Job file being read from
             </summary>
         </member>
+        <member name="F:DuetControlServer.FileExecution.Job._cancellationTokenSource">
+            <summary>
+            Internal cancellation token source used to cancel pending codes when necessary
+            </summary>
+        </member>
         <member name="P:DuetControlServer.FileExecution.Job.IsFileSelected">
             <summary>
             Indicates if a file has been selected for printing
@@ -2457,6 +2462,17 @@
         <member name="P:DuetControlServer.Settings.SpiDevice">
             <summary>
             SPI device that is connected to RepRapFirmware
+            </summary>
+        </member>
+        <member name="P:DuetControlServer.Settings.SpiBufferSize">
+            <summary>
+            SPI Tx and Rx buffer size
+            Should not be greater than the kernel spidev buffer size
+            </summary>
+        </member>
+        <member name="P:DuetControlServer.Settings.SpiTransferMode">
+            <summary>
+            SPI Transfer Mode 0-3
             </summary>
         </member>
         <member name="P:DuetControlServer.Settings.SpiFrequency">

--- a/src/DuetControlServer/SPI/DataTransfer.cs
+++ b/src/DuetControlServer/SPI/DataTransfer.cs
@@ -47,8 +47,9 @@ namespace DuetControlServer.SPI
         private static byte _packetId;
 
         // Transfer data. Keep three TX buffers so resend requests can be processed
+        private static readonly int bufferSize = Settings.SpiBufferSize;
         private const int NumTxBuffers = 3;
-        private static readonly Memory<byte> _rxBuffer = new byte[Communication.Consts.BufferSize];
+        private static readonly Memory<byte> _rxBuffer = new byte[bufferSize];
         private static readonly LinkedList<Memory<byte>> _txBuffers = new LinkedList<Memory<byte>>();
         private static LinkedListNode<Memory<byte>> _txBuffer;
         private static int _rxPointer, _txPointer;
@@ -72,7 +73,7 @@ namespace DuetControlServer.SPI
             // Initialize TX buffers
             for (int i = 0; i < NumTxBuffers; i++)
             {
-                _txBuffers.AddLast(new byte[Communication.Consts.BufferSize]);
+                _txBuffers.AddLast(new byte[bufferSize]);
             }
             _txBuffer = _txBuffers.First;
 
@@ -82,13 +83,13 @@ namespace DuetControlServer.SPI
             MonitorTransferReadyPin();
 
             // Initialize SPI device
-            _spiDevice = new SpiDevice(Settings.SpiDevice, Settings.SpiFrequency);
+            _spiDevice = new SpiDevice(Settings.SpiDevice, Settings.SpiFrequency, Settings.SpiTransferMode);
 
             // Check if large transfers can be performed
             try
             {
                 int maxSpiBufferSize = int.Parse(File.ReadAllText("/sys/module/spidev/parameters/bufsiz"));
-                if (maxSpiBufferSize < Consts.BufferSize)
+                if (maxSpiBufferSize < bufferSize)
                 {
                     _logger.Warn("Kernel SPI buffer size is smaller than RepRapFirmware buffer size ({0} configured vs {1} required)", maxSpiBufferSize, Consts.BufferSize);
                 }
@@ -589,7 +590,7 @@ namespace DuetControlServer.SPI
         public static bool WriteGetObjectModel(string key, string flags)
         {
             // Serialize the request first to see how much space it requires
-            Span<byte> span = stackalloc byte[Consts.BufferSize - Marshal.SizeOf<PacketHeader>()];
+            Span<byte> span = stackalloc byte[bufferSize - Marshal.SizeOf<PacketHeader>()];
             int dataLength = Serialization.Writer.WriteGetObjectModel(span, key, flags);
 
             // See if the request fits into the buffer
@@ -613,7 +614,7 @@ namespace DuetControlServer.SPI
         public static bool WriteSetObjectModel(string field, object value)
         {
             // Serialize the request first to see how much space it requires
-            Span<byte> span = stackalloc byte[Consts.BufferSize - Marshal.SizeOf<PacketHeader>()];
+            Span<byte> span = stackalloc byte[bufferSize - Marshal.SizeOf<PacketHeader>()];
             int dataLength = Serialization.Writer.WriteSetObjectModel(span, field, value);
 
             // See if the request fits into the buffer
@@ -636,7 +637,7 @@ namespace DuetControlServer.SPI
         public static bool WritePrintStarted(ParsedFileInfo info)
         {
             // Serialize the request first to see how much space it requires
-            Span<byte> span = stackalloc byte[Consts.BufferSize - Marshal.SizeOf<PacketHeader>()];
+            Span<byte> span = stackalloc byte[bufferSize - Marshal.SizeOf<PacketHeader>()];
             int dataLength = Serialization.Writer.WritePrintStarted(span, info);
 
             // See if the request fits into the buffer
@@ -712,7 +713,7 @@ namespace DuetControlServer.SPI
         public static bool WriteHeightMap(Heightmap map)
         {
             // Serialize the request first to see how much space it requires
-            Span<byte> span = stackalloc byte[Consts.BufferSize - Marshal.SizeOf<PacketHeader>()];
+            Span<byte> span = stackalloc byte[bufferSize - Marshal.SizeOf<PacketHeader>()];
             int dataLength = Serialization.Writer.WriteHeightMap(span, map);
 
             // See if the request fits into the buffer
@@ -875,7 +876,7 @@ namespace DuetControlServer.SPI
         public static bool WriteAssignFilament(int extruder, string filamentName)
         {
             // Serialize the request first to see how much space it requires
-            Span<byte> span = stackalloc byte[Consts.BufferSize - Marshal.SizeOf<PacketHeader>()];
+            Span<byte> span = stackalloc byte[bufferSize - Marshal.SizeOf<PacketHeader>()];
             int dataLength = Serialization.Writer.WriteAssignFilament(span, extruder, filamentName);
 
             // See if the request fits into the buffer
@@ -899,7 +900,7 @@ namespace DuetControlServer.SPI
         public static bool WriteFileChunk(Span<byte> data, long fileLength)
         {
             // Serialize the request first to see how much space it requires
-            Span<byte> span = stackalloc byte[Consts.BufferSize - Marshal.SizeOf<PacketHeader>()];
+            Span<byte> span = stackalloc byte[bufferSize - Marshal.SizeOf<PacketHeader>()];
             int dataLength = Serialization.Writer.WriteFileChunk(span, data, fileLength);
 
             // See if the request fits into the buffer
@@ -923,7 +924,7 @@ namespace DuetControlServer.SPI
         public static bool WriteEvaluateExpression(CodeChannel channel, string expression)
         {
             // Serialize the request first to see how much space it requires
-            Span<byte> span = stackalloc byte[Consts.BufferSize - Marshal.SizeOf<PacketHeader>()];
+            Span<byte> span = stackalloc byte[bufferSize - Marshal.SizeOf<PacketHeader>()];
             int dataLength = Serialization.Writer.WriteEvaluateExpression(span, channel, expression);
 
             // See if the request fits into the buffer
@@ -947,7 +948,7 @@ namespace DuetControlServer.SPI
         public static bool WriteMessage(MessageTypeFlags flags, string message)
         {
             // Serialize the request first to see how much space it requires
-            Span<byte> span = stackalloc byte[Consts.BufferSize - Marshal.SizeOf<PacketHeader>()];
+            Span<byte> span = stackalloc byte[bufferSize - Marshal.SizeOf<PacketHeader>()];
             int dataLength = Serialization.Writer.WriteMessage(span, flags, message);
 
             // See if the request fits into the buffer
@@ -969,7 +970,7 @@ namespace DuetControlServer.SPI
         /// <returns>True if there is enough space</returns>
         private static bool CanWritePacket(int dataLength = 0)
         {
-            return _txPointer + Marshal.SizeOf<PacketHeader>() + dataLength <= Consts.BufferSize;
+            return _txPointer + Marshal.SizeOf<PacketHeader>() + dataLength <= bufferSize;
         }
         #endregion
 
@@ -1132,7 +1133,7 @@ namespace DuetControlServer.SPI
                     ExchangeResponse(TransferResponse.BadProtocolVersion);
                     throw new Exception($"Invalid protocol version {_rxHeader.ProtocolVersion}");
                 }
-                if (_rxHeader.DataLength > Consts.BufferSize)
+                if (_rxHeader.DataLength > bufferSize)
                 {
                     ExchangeResponse(TransferResponse.BadDataLength);
                     throw new Exception($"Data too long ({_rxHeader.DataLength} bytes)");

--- a/src/DuetControlServer/Settings.cs
+++ b/src/DuetControlServer/Settings.cs
@@ -100,6 +100,17 @@ namespace DuetControlServer
         public static string SpiDevice { get; set; } = "/dev/spidev0.0";
 
         /// <summary>
+        /// SPI Tx and Rx buffer size
+        /// Should not be greater than the kernel spidev buffer size
+        /// </summary>
+        public static int SpiBufferSize { get; set; } = SPI.Communication.Consts.BufferSize;
+
+        /// <summary>
+        /// SPI Transfer Mode 0-3
+        /// </summary>
+        public static int SpiTransferMode { get; set; } = 0;
+
+        /// <summary>
         /// Frequency to use for SPI transfers (in Hz)
         /// </summary>
         public static int SpiFrequency { get; set; } = 8_000_000;

--- a/src/LinuxDevices/LinuxDevices.xml
+++ b/src/LinuxDevices/LinuxDevices.xml
@@ -67,7 +67,7 @@
             Driver class for SPI transfers. Most of this is copied from the System.Device.Gpio library
             </summary>
         </member>
-        <member name="M:LinuxDevices.SpiDevice.#ctor(System.String,System.Int32)">
+        <member name="M:LinuxDevices.SpiDevice.#ctor(System.String,System.Int32,System.Int32)">
             <summary>
             Initialize an SPI device
             </summary>

--- a/src/LinuxDevices/SpiDevice.cs
+++ b/src/LinuxDevices/SpiDevice.cs
@@ -18,7 +18,7 @@ namespace LinuxDevices
         /// </summary>
         /// <param name="devNode">Path to the /dev node</param>
         /// <param name="speed">Transfer speed in Hz</param>
-        public unsafe SpiDevice(string devNode, int speed)
+        public unsafe SpiDevice(string devNode, int speed, int transferMode)
         {
             _speed = (uint)speed;
 
@@ -28,7 +28,24 @@ namespace LinuxDevices
                 throw new IOException($"Error {Marshal.GetLastWin32Error()}. Can not open SPI device file '{devNode}'.");
             }
 
-            UnixSpiMode mode = UnixSpiMode.SPI_MODE_0;
+            UnixSpiMode mode;
+            switch (transferMode)
+            {
+                case 0:
+                    mode = UnixSpiMode.SPI_MODE_0;
+                    break;
+                case 1:
+                    mode = UnixSpiMode.SPI_MODE_1;
+                    break;
+                case 2:
+                    mode = UnixSpiMode.SPI_MODE_2;
+                    break;
+                case 3:
+                    mode = UnixSpiMode.SPI_MODE_3;
+                    break;
+                default:
+                    throw new ArgumentException($"Transfer mode '{transferMode}' not regignized. Must be between 0 and 3.");
+            }
             IntPtr nativePtr = new IntPtr(&mode);
 
             int result = Interop.ioctl(_deviceFileDescriptor, (uint)SpiSettings.SPI_IOC_WR_MODE, nativePtr);


### PR DESCRIPTION
* Added DCS parameter SpiBufferSize to allow altering the buffer
  size for small memory footprint devices.

* Added DCS parameter SpiTransferMode to allow setting the
  transfer mode for alternate platforms.

Fixes #134 