### PR TITLE
Dev lpc2

### DIFF
--- a/src/DuetControlServer/Codes/MCodes.cs
+++ b/src/DuetControlServer/Codes/MCodes.cs
@@ -79,7 +79,7 @@ namespace DuetControlServer.Codes
                         int maxSize = -1;
                         if (code.Flags.HasFlag(CodeFlags.IsFromFirmware))
                         {
-                            maxSize = SPI.Communication.Consts.MaxMessageLength;
+                            maxSize = Settings.MaxMessageLength;
                         }
 
                         // Check if JSON file lists were requested

--- a/src/DuetControlServer/SPI/Channel/Processor.cs
+++ b/src/DuetControlServer/SPI/Channel/Processor.cs
@@ -731,16 +731,16 @@ namespace DuetControlServer.SPI.Channel
 
                             // Split the message into multiple chunks so RRF can output it
                             Memory<byte> encodedMessage = Encoding.UTF8.GetBytes(result.ToString());
-                            for (int i = 0; i < encodedMessage.Length; i += Communication.Consts.MaxMessageLength)
+                            for (int i = 0; i < encodedMessage.Length; i += Settings.MaxMessageLength)
                             {
-                                if (i + Communication.Consts.MaxMessageLength >= encodedMessage.Length)
+                                if (i + Settings.MaxMessageLength >= encodedMessage.Length)
                                 {
                                     Memory<byte> partialMessage = encodedMessage[i..];
                                     Interface.SendMessage(flags, Encoding.UTF8.GetString(partialMessage.ToArray()));
                                 }
                                 else
                                 {
-                                    Memory<byte> partialMessage = encodedMessage.Slice(i, Math.Min(encodedMessage.Length - i, Communication.Consts.MaxMessageLength));
+                                    Memory<byte> partialMessage = encodedMessage.Slice(i, Math.Min(encodedMessage.Length - i, Settings.MaxMessageLength));
                                     Interface.SendMessage(flags | MessageTypeFlags.PushFlag, Encoding.UTF8.GetString(partialMessage.ToArray()));
                                 }
                             }

--- a/src/DuetControlServer/SPI/Communication/Consts.cs
+++ b/src/DuetControlServer/SPI/Communication/Consts.cs
@@ -32,19 +32,9 @@ namespace DuetControlServer.SPI.Communication
         public const int BufferSize = 8192;
 
         /// <summary>
-        /// Maximum size of a binary encoded G/M/T-code. This is limited by RepRapFirmware (see code queue)
-        /// </summary>
-        public const int MaxCodeBufferSize = 256;
-
-        /// <summary>
         /// Maximum length of a whole-line comment to send to RRF
         /// </summary>
         public const int MaxCommentLength = 100;
-
-        /// <summary>
-        /// Maximum supported length of messages to be sent to RepRapFirmware
-        /// </summary>
-        public const int MaxMessageLength = 4096;
 
         /// <summary>
         /// Maximum number of evaluation requests to send per transfer

--- a/src/DuetControlServer/SPI/DataTransfer.cs
+++ b/src/DuetControlServer/SPI/DataTransfer.cs
@@ -517,7 +517,7 @@ namespace DuetControlServer.SPI
         /// <returns>Code size in bytes</returns>
         public static int GetCodeSize(Code code)
         {
-            Span<byte> span = stackalloc byte[Consts.MaxCodeBufferSize];
+            Span<byte> span = stackalloc byte[Settings.MaxCodeBufferSize];
             try
             {
                 return Serialization.Writer.WriteCode(span, code);
@@ -536,7 +536,7 @@ namespace DuetControlServer.SPI
         public static bool WriteCode(Code code)
         {
             // Attempt to serialize the code first
-            Span<byte> span = stackalloc byte[Consts.MaxCodeBufferSize];
+            Span<byte> span = stackalloc byte[Settings.MaxCodeBufferSize];
             int codeLength;
             try
             {

--- a/src/DuetControlServer/SPI/Interface.cs
+++ b/src/DuetControlServer/SPI/Interface.cs
@@ -601,7 +601,7 @@ namespace DuetControlServer.SPI
             {
                 throw new InvalidOperationException("Incompatible firmware version");
             }
-            if (message.Length > Consts.MaxMessageLength)
+            if (message.Length > Settings.MaxMessageLength)
             {
                 throw new ArgumentException($"{nameof(message)} too long");
             }

--- a/src/DuetControlServer/Settings.cs
+++ b/src/DuetControlServer/Settings.cs
@@ -179,12 +179,12 @@ namespace DuetControlServer
         /// <summary>
         /// Maximum size of a binary encoded G/M/T-code. This is limited by RepRapFirmware (see code queue)
         /// </summary>
-        public static int MaxCodeBufferSize { get; set; } = SPI.Communication.Consts.MaxCodeBufferSize;
+        public static int MaxCodeBufferSize { get; set; } = 256;
 
         /// <summary>
         /// Maximum supported length of messages to be sent to RepRapFirmware
         /// </summary>
-        public static int MaxMessageLength { get; set; } = SPI.Communication.Consts.MaxMessageLength;
+        public static int MaxMessageLength { get; set; } = 4096;
 
         /// <summary>
         /// List of string chunks that are identified by RepRapFirmware

--- a/src/DuetControlServer/Settings.cs
+++ b/src/DuetControlServer/Settings.cs
@@ -177,6 +177,16 @@ namespace DuetControlServer
         public static int MaxBufferSpacePerChannel { get; set; } = 1536;
 
         /// <summary>
+        /// Maximum size of a binary encoded G/M/T-code. This is limited by RepRapFirmware (see code queue)
+        /// </summary>
+        public static int MaxCodeBufferSize { get; set; } = SPI.Communication.Consts.MaxCodeBufferSize;
+
+        /// <summary>
+        /// Maximum supported length of messages to be sent to RepRapFirmware
+        /// </summary>
+        public static int MaxMessageLength { get; set; } = SPI.Communication.Consts.MaxMessageLength;
+
+        /// <summary>
         /// List of string chunks that are identified by RepRapFirmware
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
This pull request allows the limits for MaxMessageLength and MaxCodeBufferSize to be set for the standard DSF configuration file. This allows them to be more easily adjusted for use with the LPC port of RRF which is unable to support the standard settings.