### PR TITLE
Update build instructions to specify .Net Core 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Since it relies on a [model subscription](#model-subscriptions), it gives an ide
 ### 3. Building things on your own
 
 Of course you can build everything on your own, too. In order to build packages like those on the package feed, check out the `build.sh` script in the `pkg` directory.
-If you wish to make changes to the existing software and to test it, you need to get the [latest .NET SDK](https://dotnet.microsoft.com/download/dotnet-core) first.
+If you wish to make changes to the existing software and to test it, you need to get the [latest .NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core) first.
 
 #### 3.1 Building on a remote system
 


### PR DESCRIPTION
The instructions specified to "get the latest .net sdk", but that's a bit confusing when there are 3 distinct branches of .net: core 2.1, core 3.1 and 5.0.  Making it more confusing, MS doesn't use the word "core" in 5.0.  A person might think "oh, 5.0 must be the latest", but it appears that DSF uses the 3.1 branch, the latest version of which is currently 3.1.11 (at the time of this comment.)  This change just clarifies "CORE 3.1"