### PR TITLE
Fix compilation failure due to use of `is not`

### DIFF
--- a/src/DuetControlServer/DuetControlServer.csproj
+++ b/src/DuetControlServer/DuetControlServer.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <LangVersion>default</LangVersion>
+    <LangVersion>9</LangVersion>
     <Authors>Christian Hammacher</Authors>
     <Company>Duet3D Ltd</Company>
     <AssemblyVersion>3.2.0.0</AssemblyVersion>


### PR DESCRIPTION
Explicitly declare minimum language version so that successful compilation doesn't rely on assumed external configuration.