### PR TITLE
Makefile update

### DIFF
--- a/pkg/rpm/duetcontrolserver.spec
+++ b/pkg/rpm/duetcontrolserver.spec
@@ -11,10 +11,10 @@
 
 Name:    duetcontrolserver
 Version: %{_tversion}
-Release: %{_release}
+Release: %{_tag:%{_tag}-}%{_release}
 Summary: DSF Control Server
 Group:   3D Printing
-Source0: duetcontrolserver_%{_tversion}
+Source0: duetcontrolserver_%{_tversion}%{_tag:-%{_tag}}
 License: GPLv3
 URL:     https://github.com/Duet3D/DuetSoftwareFramework
 BuildRequires: rpm >= 4.7.2-2
@@ -52,3 +52,6 @@ fi
 %{_unitdir}/duetcontrolserver.service
 %config(noreplace) %{dsfoptdir}/conf/config.json
 %{dsfoptdir}/bin/DuetControlServer*
+%config(noreplace) %{_sysconfdir}/udev/rules.d/99-dsf-gpio.rules
+%{_exec_prefix}/lib/sysusers.d/duetcontrolserver.conf
+%{_exec_prefix}/lib/tmpfiles.d/duetcontrolserver.conf

--- a/pkg/rpm/duetruntime.spec
+++ b/pkg/rpm/duetruntime.spec
@@ -10,10 +10,10 @@
 
 Name:    duetruntime
 Version: %{_tversion}
-Release: %{_release}
+Release: %{_tag:%{_tag}-}%{_release}
 Summary: DSF Common Runtime Components
 Group:   3D Printing
-Source0: duetruntime_%{_tversion}
+Source0: duetruntime_%{_tversion}%{_tag:-%{_tag}}
 License: GPLv3
 URL:     https://github.com/Duet3D/DuetSoftwareFramework
 BuildRequires: rpm >= 4.7.2-2

--- a/pkg/rpm/duetsd.spec
+++ b/pkg/rpm/duetsd.spec
@@ -10,10 +10,10 @@
 
 Name:    duetsd
 Version: %{_tversion}
-Release: %{_release}
+Release: %{_tag:%{_tag}-}%{_release}
 Summary: DSF SD Card
 Group:   3D Printing
-Source0: duetsd_%{_tversion}
+Source0: duetsd_%{_tversion}%{_tag:-%{_tag}}
 License: GPLv3
 URL:     https://github.com/Duet3D/DuetSoftwareFramework
 BuildRequires: rpm >= 4.7.2-2
@@ -25,9 +25,9 @@ DSF SD Card
 
 %files
 %defattr(0664,root,root,0775)
-%dir %{dsfoptdir}/sd/sys
-%config(noreplace) %{dsfoptdir}/sd/sys/config.g
 %dir %{dsfoptdir}/sd/filaments
+%dir %{dsfoptdir}/sd/firmware
 %dir %{dsfoptdir}/sd/gcodes
 %dir %{dsfoptdir}/sd/macros
-%dir %{dsfoptdir}/sd/menu
+%dir %{dsfoptdir}/sd/sys
+%config(noreplace) %{dsfoptdir}/sd/sys/config.g

--- a/pkg/rpm/duetsoftwareframework.spec
+++ b/pkg/rpm/duetsoftwareframework.spec
@@ -10,12 +10,12 @@
 
 Name:    duetsoftwareframework
 Version: %{_tversion}
-Release: %{_release}
+Release: %{_tag:%{_tag}-}%{_release}
 Summary: Duet Software Framework
 Group:   3D Printing
 License: GPLv3
 URL:     https://github.com/Duet3D/DuetSoftwareFramework
-Source0: duetsoftwareframework_%{_tversion}
+Source0: duetsoftwareframework_%{_tversion}%{_tag:-%{_tag}}
 
 BuildRequires: rpm >= 4.7.2-2
 

--- a/pkg/rpm/duettools.spec
+++ b/pkg/rpm/duettools.spec
@@ -10,10 +10,10 @@
 
 Name:    duettools
 Version: %{_tversion}
-Release: %{_release}
+Release: %{_tag:%{_tag}-}%{_release}
 Summary: DSF Tools
 Group:   3D Printing
-Source0: duettools_%{_tversion}
+Source0: duettools_%{_tversion}%{_tag:-%{_tag}}
 License: GPLv3
 URL:     https://github.com/Duet3D/DuetSoftwareFramework
 BuildRequires: rpm >= 4.7.2-2
@@ -34,3 +34,5 @@ DSF Tools
 %{dsfoptdir}/bin/CustomHttpEndpoint.*
 %attr(0755, root, root) %{dsfoptdir}/bin/ModelObserver
 %{dsfoptdir}/bin/ModelObserver.*
+%attr(0755, root, root) %{dsfoptdir}/bin/PluginManager
+%{dsfoptdir}/bin/PluginManager.*

--- a/pkg/rpm/duetwebcontrol.spec
+++ b/pkg/rpm/duetwebcontrol.spec
@@ -10,10 +10,10 @@
 
 Name:    duetwebcontrol
 Version: %{_tversion}
-Release: %{_release}
+Release: %{_tag:%{_tag}-}%{_release}
 Summary: Official web interface for Duet electronics
 Group:   3D Printing
-Source0: duetwebcontrol_%{_tversion}
+Source0: duetwebcontrol_%{_tversion}%{_tag:-%{_tag}}
 License: GPLv3
 URL:     https://github.com/Duet3D/DuetWebControl
 BuildRequires: rpm >= 4.7.2-2

--- a/pkg/rpm/duetwebserver.spec
+++ b/pkg/rpm/duetwebserver.spec
@@ -10,10 +10,10 @@
 
 Name:    duetwebserver
 Version: %{_tversion}
-Release: %{_release}
+Release: %{_tag:%{_tag}-}%{_release}
 Summary: DSF Web Server
 Group:   3D Printing
-Source0: duetwebserver_%{_tversion}
+Source0: duetwebserver_%{_tversion}%{_tag:-%{_tag}}
 License: GPLv3
 URL:     https://github.com/Duet3D/DuetSoftwareFramework
 BuildRequires: rpm >= 4.7.2-2


### PR DESCRIPTION
* Fixup RPM builds for 3.2+

* Remove bash-isms.
  For some platforms, bash isn't make's default shell which
  caused issues with the deb creation process so the
  {control,changelog} bash-isms have been removed.

Fixes #163 
