### PR TITLE
use value of Options.UpdateInterval in PollConnector.  

### DIFF
--- a/src/DuetHttpClient/Connector/PollConnector.cs
+++ b/src/DuetHttpClient/Connector/PollConnector.cs
@@ -463,7 +463,7 @@ namespace DuetHttpClient.Connector
                     // Wait a moment before attempting to reconnect
                     try
                     {
-                        await Task.Delay(2000, _terminateSession.Token);
+                        await Task.Delay(Options.UpdateInterval, _terminateSession.Token);
                     }
                     catch (OperationCanceledException)
                     {


### PR DESCRIPTION
This allows to set the time between polls at initialization time. Before was hard-coded to 2000ms.